### PR TITLE
Provide a pkg-config file.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,5 +12,6 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_FILES([
         Makefile
         src/Makefile
+        src/libsuinput.pc
 ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,3 +4,5 @@ libsuinput_la_SOURCES = suinput.c
 libsuinput_la_LDFLAGS = -l:libudev.so.0 -version-info 5:0:1
 include_HEADERS = suinput.h
 noinst_HEADERS = libudev.h
+pkgconfigdir   = $(libdir)/pkgconfig
+pkgconfig_DATA = libsuinput.pc

--- a/src/libsuinput.pc.in
+++ b/src/libsuinput.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Description: Thin userspace library on top of Linux uinput kernel module
+Version: @VERSION@
+URL: @PACKAGE_URL@
+Libs: -L${libdir} -lsuinput
+Cflags: -I${includedir}


### PR DESCRIPTION
This is quite useful for integration into another project. On
autotools-based project, the dependency can be resolved with something
like:

```
PKG_CHECK_MODULES([LIBSUINPUT], [libsuinput >= 0.5])
```
