### PR TITLE
Provide a `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+*~
+*.o
+*.lo
+*.a
+*.la
+/build*/
+
+# autotools stuff
+/m4/lt*.m4
+/m4/libtool.m4
+/aclocal.m4
+/ltmain.sh
+/install-sh
+/config.guess
+/config.h.in
+/config.sub
+/autom4te.cache/
+/compile
+/configure
+/depcomp
+/missing
+/test-driver
+
+# automake
+/Makefile.in
+/src/Makefile.in
+/ar-lib
+
+# cscope
+/cscope.*
+/GPATH
+/GRTAGS
+/GSYMS
+/GTAGS


### PR DESCRIPTION
This works fine for an out-of-tree build. Otherwise, it is incomplete.
