### PR TITLE
Enable repeat property on key event

### DIFF
--- a/src/suinput.c
+++ b/src/suinput.c
@@ -181,6 +181,9 @@ int suinput_enable_event(int uinput_fd, uint16_t ev_type, uint16_t ev_code)
 
         switch (ev_type) {
         case EV_KEY:
+                /* enable repeat property on key event,
+                   just like on a real keyboard */
+                ioctl(uinput_fd, UI_SET_EVBIT, EV_REP);
                 io = UI_SET_KEYBIT;
                 break;
         case EV_REL:


### PR DESCRIPTION
This enables repeat property on EV_KEY, so that keeping ev_value=1 in emit() makes sense.
This way, "holding" the key will give us the same behavior like on the real keyboard.