### PR TITLE
Fix: examples Makefile: put ld flags to the end

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,7 +17,7 @@ all: $(PROGRAMS)
 	$(CC) $(CPPFLAGS_ALL) $(CFLAGS_ALL) -c -o $@ $<
 
 $(PROGRAMS) : % : %.o
-	$(CC) $(LDFLAGS_ALL) $(CFLAGS_ALL) -o $@ $<
+	$(CC) $(CFLAGS_ALL) -o $@ $< $(LDFLAGS_ALL)
 
 clean:
 	rm -f $(PROGRAMS)


### PR DESCRIPTION
Trying to compile ./examples failed for me because the "-lsuinput" flag was right in the middle. I fixed the Makefile.